### PR TITLE
Namespace exec call

### DIFF
--- a/www/ASWebAuthSession.js
+++ b/www/ASWebAuthSession.js
@@ -2,7 +2,7 @@ var PLUGIN_NAME = 'ASWebAuthSession';
 function ASWebAuthSession() {}
 
 ASWebAuthSession.prototype.start = function(redirectScheme, requestURL, callback, errorCallback) {
-  exec(callback, errorCallback, PLUGIN_NAME, 'start', [redirectScheme, requestURL]);
+  cordova.exec(callback, errorCallback, PLUGIN_NAME, 'start', [redirectScheme, requestURL]);
 }
 
 ASWebAuthSession.install = function () {


### PR DESCRIPTION
I'm using this with Capacitor and I had to put in the proper namespace for the Cordova exec call. Don't know if this is always needed? But if so here is PR to fix it.
