### PR TITLE
Fix for Xcode 12.5 [NSInvalidArgumentException]

### DIFF
--- a/src/ios/ASWebAuthSession.m
+++ b/src/ios/ASWebAuthSession.m
@@ -25,7 +25,7 @@ ASWebAuthenticationSession *_asAuthenticationVC;
 
         ASWebAuthenticationSession* authenticationVC =
         [[ASWebAuthenticationSession alloc] initWithURL:requestURL
-                                   callbackURLScheme:redirectScheme
+                                   callbackURLScheme: [[NSURL URLWithString: redirectScheme] scheme]
                                    completionHandler:^(NSURL * _Nullable callbackURL,
                                                        NSError * _Nullable error) {
                                        CDVPluginResult *result;


### PR DESCRIPTION
Since building with Xcode 12.5 our redirect URI no longer works, error:

`NSInvalidArgumentException Reason: The provided scheme is not valid. A scheme should not include special characters such as ":" or "/".`

The reason seems to be a SDK change, please see also: https://github.com/auth0/react-native-auth0/pull/369